### PR TITLE
Chore/update ci user

### DIFF
--- a/.github/workflows/autofix-profile.yml
+++ b/.github/workflows/autofix-profile.yml
@@ -16,7 +16,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref:  ${{ github.head_ref }}
-      - uses: tibdex/github-app-token@v1
+      - name: Generate app token
+        uses: tibdex/github-app-token@v1
         id: get_installation_token
         with: 
           app_id: ${{ secrets.APP_ID }}

--- a/.github/workflows/autofix-profile.yml
+++ b/.github/workflows/autofix-profile.yml
@@ -11,13 +11,18 @@ jobs:
   auto-update:
     name: Autofix profile content
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Clone
         uses: actions/checkout@v3
         with:
           ref:  ${{ github.head_ref }}
+      - uses: tibdex/github-app-token@v1
+        id: get_installation_token
+        with: 
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+          permissions: >-
+            {"contents": "write", "pull_requests": "write"}
       - name: Autofix profile
         id: autofix-profile
         uses: RedHatProductSecurity/trestle-bot@main
@@ -28,4 +33,4 @@ jobs:
           file_pattern: "*.json,markdown/*"
           skip_items: "fedramp_rev5_high"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_installation_token.outputs.token }}

--- a/.github/workflows/autofix-profile.yml
+++ b/.github/workflows/autofix-profile.yml
@@ -22,7 +22,7 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
           permissions: >-
-            {"contents": "write", "pull_requests": "write"}
+            {"contents": "write"}
       - name: Autofix profile
         id: autofix-profile
         uses: RedHatProductSecurity/trestle-bot@main

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -18,6 +18,8 @@ jobs:
         with: 
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
+          permissions: >-
+            {"actions": "write"}
       - uses: actions/github-script@v6
         with:
           github-token: ${{ steps.get_installation_token.outputs.token }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,7 @@
 name: Evaluate profiles
 on:
   pull_request:
-    types: [ opened, review_requested, ready_for_review, reopened, synchronize ]
+    types: [ opened, ready_for_review, reopened, synchronize ]
     branches:
       - main
     paths:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,12 +26,8 @@ jobs:
           oscal_model: "profile"
           check_only: true
           skip_items: "fedramp_rev5_high"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   call-autofix:
     needs: [test]
-    permissions:
-      contents: write
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     uses: ./.github/workflows/autofix-profile.yml


### PR DESCRIPTION
Update the access token used with trestle-bot Action to workaround [limitations ](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)with the generated GITHUB_TOKEN. 