### PR TITLE
chore: update tibdex/github-app-token to v2.1.0

### DIFF
--- a/.github/workflows/autofix-profile.yml
+++ b/.github/workflows/autofix-profile.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate app token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         id: get_installation_token
         with: 
           app_id: ${{ secrets.APP_ID }}

--- a/.github/workflows/create-new.yml
+++ b/.github/workflows/create-new.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate app token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         id: get_installation_token
         with: 
           app_id: ${{ secrets.APP_ID }}

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -13,7 +13,7 @@ jobs:
     name: Dispatch to Downstreams
     runs-on: ubuntu-latest
     steps:
-      - uses: tibdex/github-app-token@v1
+      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         id: get_installation_token
         with: 
           app_id: ${{ secrets.APP_ID }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -4,7 +4,8 @@ name: MegaLinter
 on:
   push:
   pull_request:
-    branches: main
+    branches: 
+    - main
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/regenerate-profile.yml
+++ b/.github/workflows/regenerate-profile.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate app token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         id: get_installation_token
         with: 
           app_id: ${{ secrets.APP_ID }}

--- a/.github/workflows/update-upstream.yml
+++ b/.github/workflows/update-upstream.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Generate app token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
         id: get_installation_token
         with: 
           app_id: ${{ secrets.APP_ID }}


### PR DESCRIPTION
Pin version to commit

Update tested here -
https://github.com/jpower432/oscal-profiles/actions/runs/6507954138