### PR TITLE
chore: update validate.yml to run evaluation only on PRs from forks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Clone
         uses: actions/checkout@v3
-        with:
-          ref:  ${{ github.head_ref }}
       - name: Check profile
         id: check-profile
         uses: RedHatProductSecurity/trestle-bot@v0.1.1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,7 +29,9 @@ jobs:
     
   call-autofix:
     needs: [test]
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: |
+      always() && contains(needs.*.result, 'failure')
+      && github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url
     uses: ./.github/workflows/autofix-profile.yml
     with:
       branch: ${{ github.head_ref }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,12 +1,16 @@
 name: Evaluate profiles
 on:
   pull_request:
-    types: [ opened, ready_for_review, reopened, synchronize ]
     branches:
       - main
     paths:
       - 'profiles/**'
       - 'markdown/profiles/**'
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Evaluate profiles


### PR DESCRIPTION
# What Changed?

- Adds a conditional statement to skip autofix if the PR is from a fork. The evaluation will run and if it fails, the PR author can fix it manually.
- Adds a concurrency group to ensure validations are not running for the same branch concurrently