### PR TITLE
feat: adds release workflow

### DIFF
--- a/.github/workflows/create-new.yml
+++ b/.github/workflows/create-new.yml
@@ -22,7 +22,7 @@ jobs:
     name: Create profile
     runs-on: ubuntu-latest
     container:
-      image: quay.io/continuouscompliance/trestle-bot:v0.7.0
+      image: quay.io/continuouscompliance/trestle-bot:v0.8.0
     steps:
       - name: Generate app token
         uses: tibdex/github-app-token@v2.1.0

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,12 +1,8 @@
 name: Dispatch downstreams
 
 on:
-  workflow_call:
-  workflow_dispatch:
-  workflow_run:
-    workflows: [Regenerate profile content]
-    types:
-      - completed
+  release:
+    types: [published]
 
 jobs:
   dispatch:
@@ -28,6 +24,9 @@ jobs:
               owner: 'RedHatProductSecurity',
               repo: 'oscal-component-definitions',
               workflow_id: 'update-profiles.yml',
+              inputs: {
+                ref: '${{ github.event.release.tag_name }}'
+              },
               ref: 'main'
             })
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: '${{ github.event.inputs.version }}',
-              name: 'v${{ github.event.inputs.version }}',
+              name: '${{ github.event.inputs.version }}',
               generate_release_notes: true,
             })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release content
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        uses: tibdex/github-app-token@v2.1.0
+        id: get_installation_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+          permissions: >-
+            {"contents": "write"}
+      - name: Clone
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.get_installation_token.outputs.token }}
+      - name: Autosync
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.8.0
+        with:
+          markdown_path: "markdown/profiles"
+          oscal_model: "profile"
+          commit_message: "Update content for release [skip ci]"
+          skip_regenerate: true
+          commit_user_name: "trestle-bot[bot]"
+          commit_user_email: "136850459+trestle-bot[bot]@users.noreply.github.com"
+          version: ${{ github.event.inputs.version }}
+      - name: Create and push tags
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+            git tag "${VERSION}"
+            git push origin "${VERSION}"
+      - name: Create Release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.get_installation_token.outputs.token }}
+          script: |
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: '${{ github.event.inputs.version }}',
+              name: 'v${{ github.event.inputs.version }}',
+              generate_release_notes: true,
+            })

--- a/.github/workflows/update-upstream.yml
+++ b/.github/workflows/update-upstream.yml
@@ -25,7 +25,7 @@ jobs:
     name: Update content
     runs-on: ubuntu-latest
     container:
-      image: quay.io/continuouscompliance/trestle-bot:v0.7.0
+      image: quay.io/continuouscompliance/trestle-bot:v0.8.0
     steps:
       - name: Generate app token
         uses: tibdex/github-app-token@v2.1.0


### PR DESCRIPTION
Closes #81 

`trestle-bot` added setting the version on the OSCAL documents during assemble (already available with `compliance-trestle`). This uses that functionality to create a release workflow for content for notify the downstream `component-definitions` repository

Needs - https://github.com/RedHatProductSecurity/oscal-component-definitions/pull/86