### PR TITLE
refactor: trestle-bot migration from check_only

### DIFF
--- a/.github/workflows/autosync-profile.yml
+++ b/.github/workflows/autosync-profile.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ steps.get_installation_token.outputs.token }}
       - name: autosync profile
         id: autosync-profile
-        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.8.0
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.9.0
         with:
           markdown_path: "markdown/profiles"
           oscal_model: "profile"

--- a/.github/workflows/create-new.yml
+++ b/.github/workflows/create-new.yml
@@ -22,7 +22,7 @@ jobs:
     name: Create profile
     runs-on: ubuntu-latest
     container:
-      image: quay.io/continuouscompliance/trestle-bot:v0.8.0
+      image: quay.io/continuouscompliance/trestle-bot:v0.9.0
     steps:
       - name: Generate app token
         uses: tibdex/github-app-token@v2.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           token: ${{ steps.get_installation_token.outputs.token }}
       - name: Autosync
-        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.8.0
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.9.0
         with:
           markdown_path: "markdown/profiles"
           oscal_model: "profile"

--- a/.github/workflows/update-upstream.yml
+++ b/.github/workflows/update-upstream.yml
@@ -79,7 +79,7 @@ jobs:
             "profiles/${FEDRAMP_PROFILE_NAME}"
       - name: Regenerate profiles
         if: ${{ steps.updates.outputs.pull-request-number }}
-        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.8.0
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.9.0
         with:
           markdown_path: "markdown/profiles"
           oscal_model: "profile"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,13 +22,19 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
       - name: Check profile
-        id: check-profile
+        id: check
         uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.9.0
         with:
           markdown_path: "markdown/profiles"
           oscal_model: "profile"
-          check_only: true
           skip_items: "fedramp_rev5_high"
+          dry_run: true
+      - name: Fail
+        if: ${{ steps.check.outputs.changes == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+              core.setFailed('Changes detected. Manual intervention may be required.')
     
   call-autosync:
     needs: [test]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Check profile
         id: check-profile
-        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.8.0
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.9.0
         with:
           markdown_path: "markdown/profiles"
           oscal_model: "profile"


### PR DESCRIPTION
Updates GitHub Actions workflow for breaking changes in trestle-bot v0.9.0.

Testing completed in fork [here](https://github.com/jpower432/oscal-profiles/pull/19).